### PR TITLE
A few small changes

### DIFF
--- a/Projects/WIN10XPE/00-Configures/x-Account/Admin/SwitchToAdmin.bat
+++ b/Projects/WIN10XPE/00-Configures/x-Account/Admin/SwitchToAdmin.bat
@@ -84,7 +84,7 @@ if "x%opt[account.custom_admin_name]%"=="x%opt[account.localized_admin_name]%" s
 if not "x%opt[account.custom_admin_name]%"=="x" (
   expand Security.cab -F:* "%X_WIN%\Security"
   call TextReplace "%X_WIN%\Security\Templates\unattend.inf" "#qAdministrator#q" "#q%opt[account.custom_admin_name]%#q"
-  if exist "%X_SYS%\PecmdAdmin.ini" call TextReplace "%X_SYS%\%PECMDINI%" "Administrator" "%opt[account.custom_admin_name]%" /g
+  if exist "%X_SYS%\PecmdAdmin.ini" call TextReplace "%X_SYS%\%PECMDINI%" "Administrator" "%opt[account.custom_admin_name]%" g
   if exist "%X_PEMaterial%\pecmd.lua" call TextReplace "%X_PEMaterial%\pecmd.lua" "'DefaultUserName', 'Administrator'" "'DefaultUserName', '%opt[account.custom_admin_name]%'"
 
   if /i not "%opt[account.custom_admin_name]%"=="Administrator" (

--- a/Projects/WIN10XPE/01-Components/00-Shell/_CustomDesktopItems.bat
+++ b/Projects/WIN10XPE/01-Components/00-Shell/_CustomDesktopItems.bat
@@ -17,7 +17,7 @@ call LuaPin -done
 
 call LuaPin -init "%X_Startup%\PinShortcuts.lua"
 
-call LinkToDesktop Explorer.lnk Explorer.exe
+call LinkToDesktop "#{@shell32.dll,22067}.lnk" Explorer.exe
 call LinkToDesktop "#{@shell32.dll,22022}.lnk" cmd.exe
 
 set _SU_ICON=319

--- a/Projects/WIN10XPE/02-Apps/Explorer++/main.bat
+++ b/Projects/WIN10XPE/02-Apps/Explorer++/main.bat
@@ -1,19 +1,130 @@
+set APP_File=explorer++_1.3.5_x%_V8664%.zip
 set APP_NAME=Explorer++
-call App pull https://explorerplusplus.com/software/explorer++_1.3.5_x%_V8664%.zip
-call :BUILD
-
-if "%WB_PE_LANG%"=="zh-CN" (
-    call App pull https://explorerplusplus.com/software/translations/explorer++_1.3.5_ZH.zip
-    call :LANG 4 
-)
-goto :EOF
-
-:BUILD
+call App pull https://explorerplusplus.com/software/%APP_FILE%
 call V2X "%APP_CACHE%" -extract "%APP_FILE%" "%X_PF%\%APP_NAME%\"
 del /f /q /a "%X_PF%\%APP_NAME%\*.txt"
-goto :EOF
+call LinkToDesktop "%APP_NAME%.lnk" "#pProgramFiles#p\%APP_NAME%\%APP_NAME%.exe"
+call LinkToStartMenu "%APP_NAME%\%APP_NAME%.lnk" "#pProgramFiles#p\%APP_NAME%\%APP_NAME%.exe"
+call PinToTaskbar "#pProgramFiles#p\%APP_NAME%\%APP_NAME%.exe"
+call PinToStartmenu "#pProgramFiles#p\%APP_NAME%\%APP_NAME%.exe"
+
+rem ---- Language Selection. ----
+if "%WB_PE_LANG%"=="cs-CZ" (
+    set APP_LANG=explorer++_1.3.5_CS.zip
+    set LNG_VALUE=0x05
+    call :LANG
+)
+if "%WB_PE_LANG%"=="da-DK" (
+    set APP_LANG=explorer++_1.3.5_DA.zip
+    set LNG_VALUE=0x06
+    call :LANG
+)
+if "%WB_PE_LANG%"=="de-DE" (
+    set APP_LANG=explorer++_1.3.5_DE.zip
+    set LNG_VALUE=0x07
+    call :LANG
+)
+if "%WB_PE_LANG%"=="es-ES" (
+    set APP_LANG=explorer++_1.3.5_ES.zip
+    set LNG_VALUE=0x0a
+    call :LANG
+)
+if "%WB_PE_LANG%"=="fr-FR" (
+    set APP_LANG=explorer++_1.3.5_FR.zip
+    set LNG_VALUE=0x0c
+    call :LANG
+)
+if "%WB_PE_LANG%"=="hu-HU" (
+    set APP_LANG=explorer++_1.3.5_HU.zip
+    set LNG_VALUE=0x0e
+    call :LANG
+)
+if "%WB_PE_LANG%"=="it-IT" (
+    set APP_LANG=explorer++_1.3.5_IT.zip
+    set LNG_VALUE=0x10
+    call :LANG
+)
+if "%WB_PE_LANG%"=="ja-jp" (
+    set APP_LANG=explorer++_1.3.5_JA.zip
+    set LNG_VALUE=0x11
+    call :LANG
+)
+if "%WB_PE_LANG%"=="ko-KR" (
+    set APP_LANG=explorer++_1.3.5_KO.zip
+    set LNG_VALUE=0x12
+    call :LANG
+)
+if "%WB_PE_LANG%"=="nb-NO" (
+    set APP_LANG=explorer++_1.3.5_NO.zip
+    set LNG_VALUE=0x14
+    call :LANG
+)
+if "%WB_PE_LANG%"=="nl-NL" (
+    set APP_LANG=explorer++_1.3.5_NL.zip
+    set LNG_VALUE=0x13
+    call :LANG
+)
+if "%WB_PE_LANG%"=="pl-PL" (
+    set APP_LANG=explorer++_1.3.5_PL.zip
+    set LNG_VALUE=0x15
+    call :LANG
+)
+if "%WB_PE_LANG%"=="pt-PT" (
+    set APP_LANG=explorer++_1.3.5_PT.zip
+    set LNG_VALUE=0x16
+    call :LANG
+)
+if "%WB_PE_LANG%"=="ro-RO" (
+    set APP_LANG=explorer++_1.3.5_RO.zip
+    set LNG_VALUE=0x18
+    call :LANG
+)
+if "%WB_PE_LANG%"=="ru-RU" (
+    set APP_LANG=explorer++_1.3.5_RU.zip
+    set LNG_VALUE=0x19
+    call :LANG
+)
+if "%WB_PE_LANG%"=="sv-SE" (
+    set APP_LANG=explorer++_1.3.5_SV.zip
+    set LNG_VALUE=0x1d
+    call :LANG
+)
+if "%WB_PE_LANG%"=="tr-TR" (
+    set APP_LANG=explorer++_1.3.5_TR.zip
+    set LNG_VALUE=0x1f
+    call :LANG
+)
+if "%WB_PE_LANG%"=="uk-UA" (
+    set APP_LANG=explorer++_1.3.5_UK.zip
+    set LNG_VALUE=0x22
+    call :LANG
+)
+if "%WB_PE_LANG%"=="zh-CN" (
+    set APP_LANG=explorer++_1.3.5_ZH.zip
+    set LNG_VALUE=0x04
+    call :LANG
+)
+call :MANUAL
 
 :LANG
-call V2X "%APP_CACHE%" -extract "%APP_FILE%" "%X_PF%\%APP_NAME%\"
-reg add "HKLM\Tmp_SOFTWARE\Explorer++\Settings" /v Language /t REG_DWORD /d %1 /f
+call App pull https://explorerplusplus.com/software/translations/%APP_LANG%
+call V2X "%APP_CACHE%" -extract "%APP_LANG%" "%X_PF%\%APP_NAME%\"
+reg add "HKLM\Tmp_Default\Software\Explorer++\Settings" /v "Language" /t REG_DWORD /d "%LNG_VALUE%" /f
+goto :EOF
+
+:MANUAL
+rem If your language can not detect automaticaly,
+rem uncomment it below, if it exist.
+rem Catalan (ca-ES), avaiable in LangPacks only:
+rem call App pull https://explorerplusplus.com/software/translations/explorer++_1.3.5_CA.zip
+rem call V2X "%APP_CACHE%" -extract "explorer++_1.3.5_CA.zip" "%X_PF%\%APP_NAME%\"
+rem reg add "HKLM\Tmp_Default\Software\Explorer++\Settings" /v "Language" /t REG_DWORD /d 0x03 /f
+rem Farsi, in Microsoft docs i not found it:
+rem call App pull https://explorerplusplus.com/software/translations/explorer++_1.3.5_FA.zip
+rem call V2X "%APP_CACHE%" -extract "explorer++_1.3.5_FA.zip" "%X_PF%\%APP_NAME%\"
+rem reg add "HKLM\Tmp_Default\Software\Explorer++\Settings" /v "Language" /t REG_DWORD /d 0x29 /f
+rem Sinhala (si-LK), avaiable in LangPacks only:
+rem call App pull https://explorerplusplus.com/software/translations/explorer++_1.3.5_SI.zip
+rem call V2X "%APP_CACHE%" -extract "explorer++_1.3.5_SI.zip" "%X_PF%\%APP_NAME%\"
+rem reg add "HKLM\Tmp_Default\Software\Explorer++\Settings" /v "Language" /t REG_DWORD /d 0x5b /f
 goto :EOF

--- a/Projects/WIN10XPE/_CustomFiles_/PEMaterial/Autoruns/Startup/BeforeShell/Shortcuts.lua
+++ b/Projects/WIN10XPE/_CustomFiles_/PEMaterial/Autoruns/Startup/BeforeShell/Shortcuts.lua
@@ -8,7 +8,7 @@
 
 -- LINK('%Programs%\\System Tools\\#{@shell32.dll,22022}.lnk', 'cmd.exe')
 
--- LINK('%Desktop%\\Explorer.lnk', 'Explorer.exe')
+-- LINK('%Desktop%\\#{@shell32.dll,22067}.lnk', 'Explorer.exe')
 -- LINK('%Desktop%\\#{@shell32.dll,22022}.lnk', 'cmd.exe')
 -- LINK('%Desktop%\\Internet Explorer.lnk', '%ProgramFiles%\\Internet Explorer\\iexplore.exe')
 


### PR DESCRIPTION
Hi slore, here are a few small changes:
rewrote Explorer++ to automatically detect the language,
fixed the WimBuilder2\Projects\WIN10XPE\00-Configurations\x-Account\Admin\SwitchToAdmin file.bat -
the value of custom_admin_name has not changed.
And the Explorer label was localized using shell32.dll
like the command line.
I wrote down all the explanations in the commits.
