### PR TITLE
App-PENetwork

### DIFF
--- a/Projects/WIN10XPE/02-Apps/PENetwork/main.bat
+++ b/Projects/WIN10XPE/02-Apps/PENetwork/main.bat
@@ -2,3 +2,10 @@ call V2X PENetwork -extract "PENetwork%_V_x64%.7z" "%X_PF%\PENetwork\"
 reg import PENetwork_Settings.reg
 
 call LinkToDesktop PENetwork.lnk "#pProgramFiles#p\PENetwork\PENetwork.exe"
+
+del /f /q /a "%X_PF%\PENetwork\*.txt"
+if exist "%X_PF%\PENetwork\PENetwork_%WB_PE_LANG%.lng" (
+  ren "%X_PF%\PENetwork\PENetwork_%WB_PE_LANG%.lng" "PENetwork_%WB_PE_LANG%.bak"
+  del /f /q /a "%X_PF%\PENetwork\*.lng"
+  ren "%X_PF%\PENetwork\PENetwork_%WB_PE_LANG%.bak" "PENetwork_%WB_PE_LANG%.lng"
+)


### PR DESCRIPTION
The unnecessary languages and two license files are cleaned.
After startup WinPE, no one will read these licenses, and the language will not be changed either.
I think there are no violations, because the archive with the original version of the program remains unchanged.