### PR TITLE
WimBuilder2\Projects\Win10XPE\za-Slim\Slim_Safely.bat

### DIFF
--- a/Projects/WIN10XPE/za-Slim/Slim_Safely.bat
+++ b/Projects/WIN10XPE/za-Slim/Slim_Safely.bat
@@ -12,7 +12,7 @@ goto :EOF
 
 :_Slim_font
 rem ==============================================
-call :KEEP_FILES \Windows\Fonts\ "app%WB_PE_OEMCP%.fon,consola.ttf,marlett.ttf,micross.ttf,tahoma.ttf,segmdl2.ttf,tahoma.ttf,tahomabd.ttf"
+call :KEEP_FILES \Windows\Fonts\ "app%WB_PE_OEMCP%.fon,consola.ttf,marlett.ttf,micross.ttf,segmdl2.ttf,tahoma.ttf,tahomabd.ttf"
 call :KEEP_FILES \Windows\Fonts\ "svgafix.fon,svgasys.fon,vga%WB_PE_OEMCP%.fon,vgafix.fon,vgafixr.fon,vgaoem.fon,vgasys.fon,vgasysr.fon"
 if "x%WB_PE_LANG%"=="xen-US" (
   call :KEEP_FILES \Windows\Fonts\ "segoeui.ttf,segoeuib.ttf,segoeuii.ttf"
@@ -44,7 +44,7 @@ goto :EOF
 :_Slim_keyboard
 rem ==============================================
 set _LocaleId=
-for /f "tokens=3" %%l in ('reg query "HKLM\Tmp_SYSTEM\ControlSet001\Control\Nls\Locale" /ve') do (
+for /f "tokens=4" %%l in ('reg query "HKLM\Tmp_SYSTEM\ControlSet001\Control\Nls\Locale" /ve') do (
   set _LocaleId=%%l
 )
 if "x%_LocaleId%"=="x" (

--- a/Projects/WIN10XPE/za-Slim/Slim_Safely.bat
+++ b/Projects/WIN10XPE/za-Slim/Slim_Safely.bat
@@ -44,7 +44,7 @@ goto :EOF
 :_Slim_keyboard
 rem ==============================================
 set _LocaleId=
-for /f "tokens=4" %%l in ('reg query "HKLM\Tmp_SYSTEM\ControlSet001\Control\Nls\Locale" /ve') do (
+for /f "tokens=3" %%l in ('reg query "HKLM\Tmp_SYSTEM\ControlSet001\Control\Nls\Locale" /v "(Default)"') do (
   set _LocaleId=%%l
 )
 if "x%_LocaleId%"=="x" (


### PR DESCRIPTION
The localized keyboard layout file was not keeped.
In line 15, in fonts, tahoma.ttf was written twice.